### PR TITLE
TensorFI: Add state space based random sampling

### DIFF
--- a/TensorFI/fiConfig.py
+++ b/TensorFI/fiConfig.py
@@ -171,10 +171,11 @@ class FIConfig(object):
 		res.append(" }")
 		return "\n".join(res)
 
-	def __init__(self,fiParams):
+	def __init__(self, fiParams, opProbabilities):
 		"Configure the initial fault injection parameters from the fiParams Dictionary"
 		# First configure the Scalar fault type
 		# Default value of fault is NoFault
+		self.opProbabilities = opProbabilities
 		if fiParams.has_key(Fields.ScalarFaultType.value):
 			faultTypeScalar = fiParams[Fields.ScalarFaultType.value]
 		else:	

--- a/TensorFI/injectFault.py
+++ b/TensorFI/injectFault.py
@@ -23,7 +23,7 @@ logInjection = True	# log fault injection and checking
 # and is called from TensorFI.py's constructor
 
 # NOTE: This has to be in this module or else fiConf won't be accessible
-def initFIConfig(fiParams):
+def initFIConfig(fiParams, opProbabilities = []):
 	"Initialize the global variable fiConf with the params"
 	global fiConf
 	global count
@@ -36,7 +36,7 @@ def initFIConfig(fiParams):
 	# which op to be injected in the whole run
 	global injectedOp
 
-	fiConf = FIConfig(fiParams)
+	fiConf = FIConfig(fiParams, opProbabilities)
 	logging.debug("Initialized config file : " + str(fiConf))
 	
 	# Setup the random seed for the fault injector if one is specified
@@ -234,7 +234,7 @@ def condPerturb(op, res):
 				totalVistedOp += 1
 				# select one random op to be injected in the whole run
 				if(injectedOp == 0):
-					injectedOp = np.random.randint(low=1, high=totalInstance+1) 
+					injectedOp = np.random.choice(totalInstance, 1, fiConf.opProbabilities) + 1
 				# inject fault at the output of the operation
 				if(totalVistedOp == injectedOp):
 					res = perturb(res)


### PR DESCRIPTION
For the "oneFaultPerRun" mode, faults were injected into
operators sampled from a uniform probability distribution.

However it makes more sense to sample across the operator
state space as it is a closer model for fault occurence.

Signed-off-by: Niranjhana Narayanan <nniranjhana@ece.ubc.ca>