### PR TITLE
benchmarks: Add CNN model basic support

### DIFF
--- a/TensorFI/fiConfig.py
+++ b/TensorFI/fiConfig.py
@@ -27,6 +27,7 @@ class Ops(Enum):
 	EQUAL = "EQUAL"
 	NOT_EQUAL = "NOT-EQUAL"
 	LESS_EQUAL = "LESS-EQUAL"
+	GREATER_EQUAL = "GREATER-EQUAL"
 	CAST = "CAST"
 	MEAN = "MEAN"
 	COUNT_NONZERO = "COUNT-NONZERO"
@@ -56,6 +57,7 @@ class Ops(Enum):
 	END = "END"  # Dummy operation for end of list
 	LRN = "LRN" 
 	ELU = "ELU"
+	RANDOM_UNIFORM = "RANDOM-UNIFORM"
 # End of Ops
 
 # These are the list of supported Fault types below (if you add a new type, please add it here)

--- a/TensorFI/injectFault.py
+++ b/TensorFI/injectFault.py
@@ -513,6 +513,14 @@ def injectFaultLessEqual(a, b):
 	if logReturn: logging.debug("\tReturning from Less Equal " + str(res) )
 	return res
 
+def injectFaultGreaterEqual(a, b):
+	"Function to call injectFault on greater equal"
+	logging.debug("Calling Operator Greater Equal " + getArgs(a, b))
+	res = np.greater_equal(a, b)
+	res = condPerturb(Ops.GREATER_EQUAL, res)
+	if logReturn: logging.debug("\tReturning from Greater Equal " + str(res) )
+	return res
+
 def injectFaultMean(a, b):
 	"Function to call injectFault on mean"
 	logging.debug("Calling Operator mean " + getArgs(a, b))
@@ -748,8 +756,7 @@ def injectFaultLRN(a, bias, alpha, beta):
 		res = resOp.eval() 
 	res = condPerturb(Ops.LRN, res)
 	if logReturn: logging.debug("\tReturning from LRN " + str(res) )
-	return res 
-
+	return res
 
 def injectFaultELU(a):
 	"Function to call injectFault on ELU"
@@ -760,6 +767,16 @@ def injectFaultELU(a):
 		res = relu.eval()
 	res = condPerturb(Ops.ELU, res)
 	if logReturn: logging.debug("\tReturning from ELU " + str(res) )
+	return res
+
+def injectFaultRandomUniform(a):
+	"Function to call injectFault on Random Uniform"
+	logging.debug("Calling Operator RandomUniform" + getArgs(a))
+	ru = tf.random.uniform(a)
+	with tf.Session() as sess:
+		res = ru.eval()
+	res = condPerturb(Ops.RANDOM_UNIFORM, res)
+	if logReturn: logging.debug("\tReturning from Random Uniform " + str(res) )
 	return res
 
 # End of implemented operators
@@ -1117,6 +1134,7 @@ opTable = {
 			"Equal" : injectFaultEqual,
 			"NotEqual" : injectFaultNotEqual,
 			"LessEqual" : injectFaultLessEqual,
+			"GreaterEqual" : injectFaultGreaterEqual,
 			"TruncatedNormal" : injectFaultTruncatedNormal,
 			"Conv2D" : injectFaultConv2D,
 			"Relu" : injectFaultRelu, 

--- a/benchmarks/mnist-cnn/README.md
+++ b/benchmarks/mnist-cnn/README.md
@@ -1,0 +1,11 @@
+This directory contains different ML models that classify MNIST dataset.
+The performance of each of these models in the presence of faults is evaluated and compared. Performance is accuracy drop over different FI (Fault Injection) configuration settings.
+
+To disable faults, set *disableInjections* to `True`. To play with other types of FI, make changes to the corresponging YAML file.
+
+The description of each model follows:
+
+**nn.py**	- A basic neural network architecture with 4 hidder layers.
+**cnn.py**	- A basic convolutional neural network architecture.
+
+Update README here as more models are benchmarked.

--- a/benchmarks/mnist-cnn/cnn.py
+++ b/benchmarks/mnist-cnn/cnn.py
@@ -1,0 +1,143 @@
+#!/usr/bin/python
+
+""" Convolutional Neural Network.
+Build and train a convolutional neural network with TensorFlow.
+This example is using the MNIST database of handwritten digits
+(http://yann.lecun.com/exdb/mnist/)
+Author: Aymeric Damien
+Project: https://github.com/aymericdamien/TensorFlow-Examples/
+"""
+
+from __future__ import division, print_function, absolute_import
+
+import tensorflow as tf
+import TensorFI as ti
+
+# Import MNIST data
+from tensorflow.examples.tutorials.mnist import input_data
+mnist = input_data.read_data_sets("/tmp/data/", one_hot=True)
+
+# Training Parameters
+learning_rate = 0.001
+num_steps = 100
+batch_size = 128
+display_step = 10
+
+# Network Parameters
+num_input = 784 # MNIST data input (img shape: 28*28)
+num_classes = 10 # MNIST total classes (0-9 digits)
+dropout = 0.5 # Dropout, probability to keep units
+
+# tf Graph input
+X = tf.placeholder(tf.float32, [None, num_input])
+Y = tf.placeholder(tf.float32, [None, num_classes])
+keep_prob = tf.placeholder(tf.float32) # dropout (keep probability)
+
+# Create some wrappers for simplicity
+def conv2d(x, W, b, strides=1):
+    # Conv2D wrapper, with bias and relu activation
+    x = tf.nn.conv2d(x, W, strides=[1, strides, strides, 1], padding='SAME')
+    x = tf.nn.bias_add(x, b)
+    return tf.nn.relu(x)
+
+def maxpool2d(x, k=2):
+    # MaxPool2D wrapper
+    return tf.nn.max_pool(x, ksize=[1, k, k, 1], strides=[1, k, k, 1],
+                          padding='SAME')
+
+# Create model
+def conv_net(x, weights, biases, dropout):
+    # MNIST data input is a 1-D vector of 784 features (28*28 pixels)
+    # Reshape to match picture format [Height x Width x Channel]
+    # Tensor input become 4-D: [Batch Size, Height, Width, Channel]
+    x = tf.reshape(x, shape=[-1, 28, 28, 1])
+
+    # Convolution Layer
+    conv1 = conv2d(x, weights['wc1'], biases['bc1'])
+    # Max Pooling (down-sampling)
+    conv1 = maxpool2d(conv1, k=2)
+
+    # Convolution Layer
+    conv2 = conv2d(conv1, weights['wc2'], biases['bc2'])
+    # Max Pooling (down-sampling)
+    conv2 = maxpool2d(conv2, k=2)
+
+    # Fully connected layer
+    # Reshape conv2 output to fit fully connected layer input
+    fc1 = tf.reshape(conv2, [-1, weights['wd1'].get_shape().as_list()[0]])
+    fc1 = tf.add(tf.matmul(fc1, weights['wd1']), biases['bd1'])
+    fc1 = tf.nn.relu(fc1)
+    # Apply Dropout
+    fc1 = tf.nn.dropout(fc1, dropout)
+
+    # Output, class prediction
+    out = tf.add(tf.matmul(fc1, weights['out']), biases['out'])
+    return out
+
+# Store layers weight & bias
+weights = {
+    # 5x5 conv, 1 input, 32 outputs
+    'wc1': tf.Variable(tf.random_normal([5, 5, 1, 32])),
+    # 5x5 conv, 32 inputs, 64 outputs
+    'wc2': tf.Variable(tf.random_normal([5, 5, 32, 64])),
+    # fully connected, 7*7*64 inputs, 1024 outputs
+    'wd1': tf.Variable(tf.random_normal([7*7*64, 1024])),
+    # 1024 inputs, 10 outputs (class prediction)
+    'out': tf.Variable(tf.random_normal([1024, num_classes]))
+}
+
+biases = {
+    'bc1': tf.Variable(tf.random_normal([32])),
+    'bc2': tf.Variable(tf.random_normal([64])),
+    'bd1': tf.Variable(tf.random_normal([1024])),
+    'out': tf.Variable(tf.random_normal([num_classes]))
+}
+
+# Construct model
+logits = conv_net(X, weights, biases, keep_prob)
+prediction = tf.nn.softmax(logits)
+
+# Define loss and optimizer
+loss_op = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(
+    logits=logits, labels=Y))
+optimizer = tf.train.AdamOptimizer(learning_rate=learning_rate)
+train_op = optimizer.minimize(loss_op)
+
+# Evaluate model
+correct_pred = tf.equal(tf.argmax(prediction, 1), tf.argmax(Y, 1))
+accuracy = tf.reduce_mean(tf.cast(correct_pred, tf.float32))
+
+# Initialize the variables (i.e. assign their default value)
+init = tf.global_variables_initializer()
+
+# Start training
+with tf.Session() as sess:
+
+    # Run the initializer
+    sess.run(init)
+
+    for step in range(1, num_steps+1):
+        batch_x, batch_y = mnist.train.next_batch(batch_size)
+
+        # Run optimization op (backprop)
+        sess.run(train_op, feed_dict={X: batch_x, Y: batch_y, keep_prob: 0.8})
+        if step % display_step == 0 or step == 1:
+            # Calculate batch loss and accuracy
+            loss, acc = sess.run([loss_op, accuracy], feed_dict={X: batch_x,
+                                                                 Y: batch_y,
+                                                                 keep_prob: 1.0})
+            print("Step " + str(step) + ", Minibatch Loss= " + \
+                  "{:.4f}".format(loss) + ", Training Accuracy= " + \
+                  "{:.3f}".format(acc))
+
+    print("Training finished! Testing now ...")
+
+    # Calculate accuracy for 256 MNIST test images
+    print("Accuracy (with no injections):", \
+        sess.run(accuracy, feed_dict={X: mnist.test.images[:256], Y: mnist.test.labels[:256], keep_prob: 1.0}))
+
+    # Add the fault injection code here to instrument the graph
+    fi = ti.TensorFI(sess, logLevel = 100, name = "convolutional", disableInjections=False)
+
+    print("Accuracy (with injections):", \
+        sess.run(accuracy, feed_dict={X: mnist.test.images[:256], Y: mnist.test.labels[:256], keep_prob: 1.0}))

--- a/benchmarks/mnist-cnn/nn.py
+++ b/benchmarks/mnist-cnn/nn.py
@@ -1,0 +1,122 @@
+#!/usr/bin/python
+
+""" Neural Network.
+
+A 2-Hidden Layers Fully Connected Neural Network (a.k.a Multilayer Perceptron)
+implementation with TensorFlow. This example is using the MNIST database
+of handwritten digits (http://yann.lecun.com/exdb/mnist/).
+
+Links:
+    [MNIST Dataset](http://yann.lecun.com/exdb/mnist/).
+
+Author: Aymeric Damien
+Project: https://github.com/aymericdamien/TensorFlow-Examples/
+"""
+
+from __future__ import print_function
+
+# Import MNIST data
+from tensorflow.examples.tutorials.mnist import input_data
+mnist = input_data.read_data_sets("/tmp/data/", one_hot=True)
+
+import tensorflow as tf
+import TensorFI as ti
+
+import math
+import sys
+
+# Parameters
+learning_rate = 0.1
+num_steps = 500
+batch_size = 128
+display_step = 100
+
+# Network Parameters
+n_hidden_1 = 256 # 1st layer number of neurons
+n_hidden_2 = 256 # 2nd layer number of neurons
+n_hidden_3 = 256 # 3rd layer number of neurons
+n_hidden_4 = 256 
+num_input = 784 # MNIST data input (img shape: 28*28)
+num_classes = 10 # MNIST total classes (0-9 digits)
+
+# tf Graph input
+X = tf.placeholder("float", [None, num_input])
+Y = tf.placeholder("float", [None, num_classes])
+
+# Store layers weight & bias
+weights = {
+    'h1': tf.Variable(tf.random_normal([num_input, n_hidden_1])),
+    'h2': tf.Variable(tf.random_normal([n_hidden_1, n_hidden_2])),
+    'h3': tf.Variable(tf.random_normal([n_hidden_2, n_hidden_3])),
+    'h4': tf.Variable(tf.random_normal([n_hidden_3, n_hidden_4])),
+    'out': tf.Variable(tf.random_normal([n_hidden_4, num_classes]))
+}
+biases = {
+    'b1': tf.Variable(tf.random_normal([n_hidden_1])),
+    'b2': tf.Variable(tf.random_normal([n_hidden_2])),
+    'b3': tf.Variable(tf.random_normal([n_hidden_3])),
+    'b4': tf.Variable(tf.random_normal([n_hidden_4])),
+    'out': tf.Variable(tf.random_normal([num_classes]))
+}
+
+
+# Create model
+def neural_net(x):
+    # Hidden fully connected layer with 256 neurons
+    layer_1 = tf.add(tf.matmul(x, weights['h1']), biases['b1'])
+    # Hidden fully connected layer with 256 neurons
+    layer_2 = tf.add(tf.matmul(layer_1, weights['h2']), biases['b2'])
+    layer_3 = tf.add(tf.matmul(layer_2, weights['h3']), biases['b3'])
+    layer_4 = tf.add(tf.matmul(layer_3, weights['h4']), biases['b4'])
+    # Output fully connected layer with a neuron for each class
+    out_layer = tf.matmul(layer_4, weights['out']) + biases['out']
+    return out_layer
+
+# Construct model
+logits = neural_net(X)
+prediction = tf.nn.softmax(logits)
+
+# Define loss and optimizer
+loss_op = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(
+    logits=logits, labels=Y))
+optimizer = tf.train.AdamOptimizer(learning_rate=learning_rate)
+train_op = optimizer.minimize(loss_op)
+
+# Evaluate model
+correct_pred = tf.equal(tf.argmax(prediction, 1), tf.argmax(Y, 1))
+accuracy = tf.reduce_mean(tf.cast(correct_pred, tf.float32))
+
+# Initialize the variables (i.e. assign their default value)
+init = tf.global_variables_initializer()
+
+# Start training
+with tf.Session() as sess:
+
+    # Run the initializer
+    sess.run(init)
+
+    print("Training now ...")
+
+    for step in range(1, num_steps+1):
+        batch_x, batch_y = mnist.train.next_batch(batch_size)
+        
+	# Run optimization op (backprop)
+        sess.run(train_op, feed_dict={X: batch_x, Y: batch_y})
+        if step % display_step == 0 or step == 1:
+            # Calculate batch loss and accuracy
+            loss, acc = sess.run([loss_op, accuracy], feed_dict={X: batch_x,
+                                                                 Y: batch_y})
+            print("Step " + str(step) + ", Minibatch Loss= " + \
+                  "{:.4f}".format(loss) + ", Training Accuracy= " + \
+                  "{:.3f}".format(acc))
+
+    print("Training finished! Testing now ...")
+
+    print("Accuracy (with no injections):", \
+        accuracy.eval({X: mnist.test.images[:256], Y: mnist.test.labels[:256]}))
+
+    # Add the fault injection code here to instrument the graph
+    fi = ti.TensorFI(sess, name = "Neural Network 4", logLevel = 50, disableInjections = False)
+
+    print("Accuracy (with injections):", \
+        accuracy.eval({X: mnist.test.images[:256], Y: mnist.test.labels[:256]}))


### PR DESCRIPTION
The basic CNN model was failing because FI operators `RandomUniform`
and `GreaterEqual` were not implemented.

Implement them and test basic support for NN, CNN with accuracy drop.

Add README as it may not be self-explanatory.

Signed-off-by: Niranjhana Narayanan <nniranjhana@ece.ubc.ca>