### PR TITLE
Fixed issues with overflow

### DIFF
--- a/TensorFI/faultTypes.py
+++ b/TensorFI/faultTypes.py
@@ -86,22 +86,24 @@ def float2bin(number, decLength = 10):
 
 
 def randomBitFlip(val):
-	"Flip a random bit in the data to be injected" 
+	"Flip a random bit in the data to be injected"
 
 	# Split the integer part and decimal part in binary expression
 	def getBinary(number):
+		# float point datatype
+		if (isinstance(number, float)):
+			binVal = float2bin(number)
+			# split data into integer and decimal part
+			integer, dec = binVal.split(".")
 		# integer data type
-		if(floor(number) == number):
-			integer = bin(int(number)).lstrip("0b") 
+		else:
+			integer = bin(int(number)).lstrip("0b")
 			# 21 digits for integer
 			integer = integer.zfill(21)
+			# To prevent extra digits in integer
+			integer = integer[0:21]
 			# integer has no mantissa
-			dec = ''	
-		# float point datatype 						
-		else:
-			binVal = float2bin(number)				
-			# split data into integer and decimal part	
-			integer, dec = binVal.split(".")	
+			dec = ''
 		return integer, dec
 
 	# we use a tag for the sign of negative val, and then consider all values as positive values


### PR DESCRIPTION
This is a corresponding fix to Issues #39 , the ideas are:

1. When `number` is long type, say 99999999999999999999, then `floor(number)==number` will return False in Python2. (However, it will return True in Python3. As TensorFI is set in Python2, this bug might be considered.)
As such, I used `isinstance()` instead in `if...else...` statement and determined whether it is float type in the first place to avoid `ValueError: need more than 1 value to unpack` ,  **line 95, in getBinary** ,`integer = bin(int(number)).lstrip("0b")`

2. Considering the binary expression of `number`(long type) might excess 21 bits, I split the the `integer` and save the first 21 bits as the final value of `integer`