### PR TITLE
Fix random.uniform and injectFaultFloor

### DIFF
--- a/TensorFI/faultTypes.py
+++ b/TensorFI/faultTypes.py
@@ -86,22 +86,24 @@ def float2bin(number, decLength = 10):
 
 
 def randomBitFlip(val):
-	"Flip a random bit in the data to be injected" 
+	"Flip a random bit in the data to be injected"
 
 	# Split the integer part and decimal part in binary expression
 	def getBinary(number):
+		# float point datatype
+		if (isinstance(number, float)):
+			binVal = float2bin(number)
+			# split data into integer and decimal part
+			integer, dec = binVal.split(".")
 		# integer data type
-		if(floor(number) == number):
-			integer = bin(int(number)).lstrip("0b") 
+		else:
+			integer = bin(int(number)).lstrip("0b")
 			# 21 digits for integer
 			integer = integer.zfill(21)
+			# To prevent extra digits in integer
+			integer = integer[0:21]
 			# integer has no mantissa
-			dec = ''	
-		# float point datatype 						
-		else:
-			binVal = float2bin(number)				
-			# split data into integer and decimal part	
-			integer, dec = binVal.split(".")	
+			dec = ''
 		return integer, dec
 
 	# we use a tag for the sign of negative val, and then consider all values as positive values

--- a/TensorFI/fiConfig.py
+++ b/TensorFI/fiConfig.py
@@ -17,6 +17,7 @@ class Ops(Enum):
 	SHAPE = "SHAPE"
 	SIZE = "SIZE"
 	FILL = "FILL"
+	FLOOR = "FLOOR"
 	FLOORMOD = "FLOOR-MOD"
 	RANGE = "RANGE"
 	RANK = "RANK"

--- a/TensorFI/injectFault.py
+++ b/TensorFI/injectFault.py
@@ -1072,12 +1072,6 @@ def injectFaultAssignAdd(a):
 	logging.debug("Calling Operator AssignAdd")
 	raise NotImplementedError("AssignAdd")
 
-# def injectFaultFloor(a):
-# 	"Function to call injectFault on Floor"
-# 	# FIXME: Implement this functionality
-# 	logging.debug("Calling Operator Floor")
-# 	raise NotImplementedError("Floor")
-
 def injectFaultSqueeze(a):
 	"Function to call injectFault on Squeeze"
 	# FIXME: Implement this functionality

--- a/TensorFI/injectFault.py
+++ b/TensorFI/injectFault.py
@@ -790,7 +790,7 @@ def injectFaultELU(a):
 def injectFaultRandomUniform(a):
 	"Function to call injectFault on Random Uniform"
 	logging.debug("Calling Operator RandomUniform" + getArgs(a))
-	ru = tf.random.uniform(a)
+	ru = tf.random_uniform(a)
 	with tf.Session() as sess:
 		res = ru.eval()
 	res = condPerturb(Ops.RANDOM_UNIFORM, res)

--- a/TensorFI/injectFault.py
+++ b/TensorFI/injectFault.py
@@ -797,6 +797,15 @@ def injectFaultRandomUniform(a):
 	if logReturn: logging.debug("\tReturning from Random Uniform " + str(res) )
 	return res
 
+def injectFaultFloor(a):
+	"Function to call injectFault on Floor"
+	logging.debug("Calling Operator Floor" + getArgs(a))
+	res = np.floor(a)
+	res = condPerturb(Ops.FLOOR, res)
+	if logReturn: logging.debug("\tReturning from Floor " + str(res))
+	return res
+
+
 # End of implemented operators
 
 
@@ -1063,11 +1072,11 @@ def injectFaultAssignAdd(a):
 	logging.debug("Calling Operator AssignAdd")
 	raise NotImplementedError("AssignAdd")
 
-def injectFaultFloor(a):
-	"Function to call injectFault on Floor"
-	# FIXME: Implement this functionality
-	logging.debug("Calling Operator Floor")
-	raise NotImplementedError("Floor")
+# def injectFaultFloor(a):
+# 	"Function to call injectFault on Floor"
+# 	# FIXME: Implement this functionality
+# 	logging.debug("Calling Operator Floor")
+# 	raise NotImplementedError("Floor")
 
 def injectFaultSqueeze(a):
 	"Function to call injectFault on Squeeze"


### PR DESCRIPTION
1. `random.uniform` is used in TensorFlow v2. Since TensorFI is only compatible with TensorFlow v1, the equivalent code should be `random_uniform`  
2. Add `injectFaultFloor` function.